### PR TITLE
Add RunService.Running check for creating remotes

### DIFF
--- a/src/util/populateInstanceMap.ts
+++ b/src/util/populateInstanceMap.ts
@@ -6,6 +6,15 @@ export function populateInstanceMap<T extends "RemoteEvent" | "RemoteFunction">(
 	names: string[],
 	map: Map<string, CreatableInstances[T]>,
 ) {
+	if (!RunService.IsRunning()) {
+		for (const name of names) {
+			const instance = new Instance(className);
+			instance.Name = name;
+			map.set(name, instance);
+		}
+		return;
+	}
+	
 	let remotes = RunService.IsServer()
 		? ReplicatedStorage.FindFirstChild(globalName)
 		: ReplicatedStorage.WaitForChild(globalName);

--- a/src/util/populateInstanceMap.ts
+++ b/src/util/populateInstanceMap.ts
@@ -6,7 +6,7 @@ export function populateInstanceMap<T extends "RemoteEvent" | "RemoteFunction">(
 	names: string[],
 	map: Map<string, CreatableInstances[T]>,
 ) {
-	if (!RunService.IsRunning()) {
+	if (RunService.IsEdit()) {
 		for (const name of names) {
 			const instance = new Instance(className);
 			instance.Name = name;


### PR DESCRIPTION
Currently, it is not possible to import the network library in a context where you cannot yield.. i.e. a Roact story. This solves that by checking if the game is running, and if not, create empty remotes to populate the instance map.