### PR TITLE
Networking refactor

### DIFF
--- a/src/events/createClientHandler.ts
+++ b/src/events/createClientHandler.ts
@@ -71,7 +71,6 @@ export function createClientHandler<S, C>(
 		handler[name as keyof S] = createClientMethod(
 			() => setupRemote(name),
 			remote,
-			eventGuards[name]?.size() ?? 0,
 			bindables.get(name),
 			middlewareProcessor,
 		) as never;
@@ -84,7 +83,6 @@ type ClientMethod = ClientSender<unknown[]> & ClientReceiver<unknown[]>;
 function createClientMethod(
 	connect: () => void,
 	remote: RemoteEvent,
-	paramCount: number,
 	bindable?: BindableEvent,
 	process?: Middleware<unknown[], unknown>,
 ) {

--- a/src/events/createClientHandler.ts
+++ b/src/events/createClientHandler.ts
@@ -93,21 +93,11 @@ function createClientMethod(
 			remote.FireServer(...args);
 		},
 
-		connect(callback, customGuards) {
+		connect(callback) {
 			assert(bindable, `Event ${remote.Name} is not registered as a receiver.`);
 			task.defer(connect);
 
-			return bindable.Event.Connect((...args: unknown[]) => {
-				if (customGuards) {
-					for (let i = 0; i < paramCount; i++) {
-						const guard = customGuards[i];
-						if (guard !== undefined && !guard(args[i])) {
-							return;
-						}
-					}
-				}
-				return callback(...(args as never));
-			});
+			return bindable.Event.Connect(callback);
 		},
 
 		predict(...args) {

--- a/src/events/createNetworkingEvent.ts
+++ b/src/events/createNetworkingEvent.ts
@@ -43,33 +43,41 @@ export function createNetworkingEvent<S, C>(
 
 	return {
 		createServer(config, meta) {
-			if (!RunService.IsServer()) {
+			if (RunService.IsRunning() && !RunService.IsServer()) {
 				return undefined!;
 			}
 
-			setupRemotes();
-			return (server ??= createServerHandler<S, C>(
-				remotes,
-				networkInfos,
-				meta!,
-				getDefaultConfiguration(config),
-				signals,
-			));
+			if (server === undefined) {
+				setupRemotes();
+				server = createServerHandler<S, C>(
+					remotes,
+					networkInfos,
+					meta!,
+					getDefaultConfiguration(config),
+					signals,
+				);
+			}
+
+			return server;
 		},
 
 		createClient(config, meta) {
-			if (!RunService.IsClient()) {
+			if (RunService.IsRunning() && !RunService.IsClient()) {
 				return undefined!;
 			}
 
-			setupRemotes();
-			return (client ??= createClientHandler<S, C>(
-				remotes,
-				networkInfos,
-				meta!,
-				getDefaultConfiguration(config),
-				signals,
-			));
+			if (client === undefined) {
+				setupRemotes();
+				client = createClientHandler<S, C>(
+					remotes,
+					networkInfos,
+					meta!,
+					getDefaultConfiguration(config),
+					signals,
+				);
+			}
+
+			return client;
 		},
 
 		registerHandler(key, callback) {

--- a/src/events/createNetworkingEvent.ts
+++ b/src/events/createNetworkingEvent.ts
@@ -18,16 +18,16 @@ function getDefaultConfiguration<T>(config: Partial<EventCreateConfiguration<T>>
 
 export function createNetworkingEvent<S, C>(
 	globalName: string,
-	serverEvents: ArbitaryGuards,
-	clientEvents: ArbitaryGuards,
+	serverNames: string[],
+	clientNames: string[],
 ): GlobalEvent<S, C> {
 	const networkInfos = new Map<string, NetworkInfo>();
 	const remotes = new Map<string, RemoteEvent>();
 	const signals = createSignalContainer<EventNetworkingEvents>();
 
 	const setupRemotes = () => {
-		populateInstanceMap("RemoteEvent", `events-${globalName}`, Object.keys(serverEvents) as string[], remotes);
-		populateInstanceMap("RemoteEvent", `events-${globalName}`, Object.keys(clientEvents) as string[], remotes);
+		populateInstanceMap("RemoteEvent", `events-${globalName}`, serverNames, remotes);
+		populateInstanceMap("RemoteEvent", `events-${globalName}`, clientNames, remotes);
 
 		for (const [name] of remotes) {
 			networkInfos.set(name, {
@@ -42,7 +42,7 @@ export function createNetworkingEvent<S, C>(
 	let client: ClientHandler<S, C> | undefined;
 
 	return {
-		createServer(config) {
+		createServer(config, meta) {
 			if (!RunService.IsServer()) {
 				return undefined!;
 			}
@@ -51,13 +51,13 @@ export function createNetworkingEvent<S, C>(
 			return (server ??= createServerHandler<S, C>(
 				remotes,
 				networkInfos,
-				serverEvents,
+				meta!,
 				getDefaultConfiguration(config),
 				signals,
 			));
 		},
 
-		createClient(config) {
+		createClient(config, meta) {
 			if (!RunService.IsClient()) {
 				return undefined!;
 			}
@@ -66,7 +66,7 @@ export function createNetworkingEvent<S, C>(
 			return (client ??= createClientHandler<S, C>(
 				remotes,
 				networkInfos,
-				clientEvents,
+				meta!,
 				getDefaultConfiguration(config),
 				signals,
 			));

--- a/src/events/createNetworkingEvent.ts
+++ b/src/events/createNetworkingEvent.ts
@@ -1,19 +1,18 @@
 import Object from "@rbxts/object-utils";
 import { RunService } from "@rbxts/services";
-import { EventMiddlewareList } from "../middleware/types";
 import { NetworkInfo } from "../types";
 import { populateInstanceMap } from "../util/populateInstanceMap";
 import { createClientHandler } from "./createClientHandler";
 import { createServerHandler } from "./createServerHandler";
-import { ArbitaryGuards, EventConfiguration, GlobalEvent } from "./types";
+import { ArbitaryGuards, ClientHandler, EventCreateConfiguration, GlobalEvent, ServerHandler } from "./types";
 import { createSignalContainer } from "../util/createSignalContainer";
 import { EventNetworkingEvents } from "../handlers";
 
-function getDefaultConfiguration(config: Partial<EventConfiguration>) {
-	return identity<EventConfiguration>({
-		disableClientGuards: config.disableClientGuards ?? false,
-		disableServerGuards: config.disableServerGuards ?? false,
+function getDefaultConfiguration<T>(config: Partial<EventCreateConfiguration<T>>) {
+	return identity<EventCreateConfiguration<T>>({
+		middleware: config.middleware ?? {},
 		warnOnInvalidGuards: config.warnOnInvalidGuards ?? RunService.IsStudio(),
+		disableIncomingGuards: config.disableIncomingGuards ?? false,
 	});
 }
 
@@ -21,57 +20,60 @@ export function createNetworkingEvent<S, C>(
 	globalName: string,
 	serverEvents: ArbitaryGuards,
 	clientEvents: ArbitaryGuards,
-	serverMiddleware?: EventMiddlewareList<S>,
-	clientMiddleware?: EventMiddlewareList<C>,
-	partialConfig: Partial<EventConfiguration> = {},
 ): GlobalEvent<S, C> {
-	const config = getDefaultConfiguration(partialConfig);
 	const networkInfos = new Map<string, NetworkInfo>();
 	const remotes = new Map<string, RemoteEvent>();
 	const signals = createSignalContainer<EventNetworkingEvents>();
 
-	populateInstanceMap("RemoteEvent", `events-${globalName}`, Object.keys(serverEvents) as string[], remotes);
-	populateInstanceMap("RemoteEvent", `events-${globalName}`, Object.keys(clientEvents) as string[], remotes);
+	const setupRemotes = () => {
+		populateInstanceMap("RemoteEvent", `events-${globalName}`, Object.keys(serverEvents) as string[], remotes);
+		populateInstanceMap("RemoteEvent", `events-${globalName}`, Object.keys(clientEvents) as string[], remotes);
 
-	for (const [name] of remotes) {
-		networkInfos.set(name, {
-			eventType: "Event",
-			globalName,
-			name,
-		});
-	}
+		for (const [name] of remotes) {
+			networkInfos.set(name, {
+				eventType: "Event",
+				globalName,
+				name,
+			});
+		}
+	};
 
-	if (RunService.IsServer()) {
-		return {
-			server: createServerHandler(
+	let server: ServerHandler<C, S> | undefined;
+	let client: ClientHandler<S, C> | undefined;
+
+	return {
+		createServer(config) {
+			if (!RunService.IsServer()) {
+				return undefined!;
+			}
+
+			setupRemotes();
+			return (server ??= createServerHandler<S, C>(
 				remotes,
 				networkInfos,
 				serverEvents,
-				clientEvents,
-				config,
+				getDefaultConfiguration(config),
 				signals,
-				serverMiddleware,
-			),
-			client: undefined!,
-			registerHandler(key, callback) {
-				return signals.connect(key, callback);
-			},
-		};
-	} else {
-		return {
-			server: undefined!,
-			client: createClientHandler(
+			));
+		},
+
+		createClient(config) {
+			if (!RunService.IsClient()) {
+				return undefined!;
+			}
+
+			setupRemotes();
+			return (client ??= createClientHandler<S, C>(
 				remotes,
 				networkInfos,
-				serverEvents,
 				clientEvents,
-				config,
+				getDefaultConfiguration(config),
 				signals,
-				clientMiddleware,
-			),
-			registerHandler(key, callback) {
-				return signals.connect(key, callback);
-			},
-		};
-	}
+			));
+		},
+
+		registerHandler(key, callback) {
+			return signals.connect(key, callback);
+		},
+	};
 }

--- a/src/events/createServerHandler.ts
+++ b/src/events/createServerHandler.ts
@@ -113,21 +113,11 @@ function createServerMethod(
 			}
 		},
 
-		connect(callback, customGuards) {
+		connect(callback) {
 			assert(bindable, `Event ${remote.Name} is not registered as a receiver.`);
 			task.defer(connect);
 
-			return bindable.Event.Connect((player: Player, ...args: unknown[]) => {
-				if (customGuards) {
-					for (let i = 0; i < paramCount; i++) {
-						const guard = customGuards[i];
-						if (guard !== undefined && !guard(args[i])) {
-							return;
-						}
-					}
-				}
-				return callback(player, ...(args as never));
-			});
+			return bindable.Event.Connect(callback);
 		},
 
 		predict(player, ...args) {

--- a/src/events/createServerHandler.ts
+++ b/src/events/createServerHandler.ts
@@ -71,7 +71,6 @@ export function createServerHandler<S, C>(
 		handler[name as keyof C] = createServerMethod(
 			() => setupRemote(name),
 			remote,
-			eventGuards[name]?.size() ?? 0,
 			bindables.get(name),
 			middlewareProcessor,
 		) as never;
@@ -84,7 +83,6 @@ type ServerMethod = ServerSender<unknown[]> & ServerReceiver<unknown[]>;
 function createServerMethod(
 	connect: () => void,
 	remote: RemoteEvent,
-	paramCount: number,
 	bindable?: BindableEvent,
 	process?: Middleware<unknown[], unknown>,
 ) {

--- a/src/events/types.d.ts
+++ b/src/events/types.d.ts
@@ -1,7 +1,7 @@
 import { t } from "@rbxts/t";
 import {
 	FunctionParameters,
-	IntrinsicCallbackGuards,
+	IntrinsicTupleGuards,
 	IntrinsicObfuscate,
 	NetworkingObfuscationMarker,
 	StripTSDoc,
@@ -123,6 +123,6 @@ export interface GlobalEvent<S, C> {
 	): RBXScriptConnection;
 }
 
-export type EventMetadata<T> = IntrinsicObfuscate<{ [k in keyof T]: IntrinsicCallbackGuards<T[k]> }>;
+export type EventMetadata<T> = IntrinsicObfuscate<{ [k in keyof T]: IntrinsicTupleGuards<Parameters<T[k]>> }>;
 
 export type ArbitaryGuards = { [key: string]: [t.check<unknown>[], t.check<unknown> | undefined] };

--- a/src/events/types.d.ts
+++ b/src/events/types.d.ts
@@ -34,12 +34,8 @@ export interface ServerReceiver<I extends unknown[]> {
 	/**
 	 * Connect to this networking event.
 	 * @param callback The callback that will be fired
-	 * @param guards A list of guards that will only be used on this connection
 	 */
-	connect<F extends I>(
-		cb: (player: Player, ...args: F) => void,
-		guards?: { [k in keyof F]?: t.check<F[k]> },
-	): RBXScriptConnection;
+	connect(cb: (player: Player, ...args: I) => void): RBXScriptConnection;
 
 	/**
 	 * Fires a server event using player as the sender.
@@ -60,9 +56,8 @@ export interface ClientReceiver<I extends unknown[]> {
 	/**
 	 * Connect to this networking event.
 	 * @param callback The callback that will be fired
-	 * @param guards A list of guards that will only be used on this connection
 	 */
-	connect<F extends I>(cb: (...args: F) => void, guards?: { [k in keyof F]?: t.check<F[k]> }): RBXScriptConnection;
+	connect(cb: (...args: I) => void): RBXScriptConnection;
 
 	/**
 	 * Fires a client event.

--- a/src/events/types.d.ts
+++ b/src/events/types.d.ts
@@ -1,5 +1,11 @@
 import { t } from "@rbxts/t";
-import { FunctionParameters, NetworkingObfuscationMarker, StripTSDoc } from "../types";
+import {
+	FunctionParameters,
+	IntrinsicCallbackGuards,
+	IntrinsicObfuscate,
+	NetworkingObfuscationMarker,
+	StripTSDoc,
+} from "../types";
 import { EventNetworkingEvents } from "../handlers";
 import { EventMiddlewareList } from "../middleware/types";
 
@@ -97,14 +103,14 @@ export interface GlobalEvent<S, C> {
 	 *
 	 * @metadata macro {@link config intrinsic-const} {@link config intrinsic-middleware}
 	 */
-	createServer(config: Partial<EventCreateConfiguration<S>>): ServerHandler<C, S>;
+	createServer(config: Partial<EventCreateConfiguration<S>>, meta?: EventMetadata<S>): ServerHandler<C, S>;
 
 	/**
 	 * This is the client implementation of the network and does not exist on the server.
 	 *
 	 * @metadata macro {@link config intrinsic-const} {@link config intrinsic-middleware}
 	 */
-	createClient(config: Partial<EventCreateConfiguration<C>>): ClientHandler<S, C>;
+	createClient(config: Partial<EventCreateConfiguration<C>>, meta?: EventMetadata<C>): ClientHandler<S, C>;
 
 	/**
 	 * Registers a networking event handler.
@@ -116,5 +122,7 @@ export interface GlobalEvent<S, C> {
 		callback: EventNetworkingEvents[K],
 	): RBXScriptConnection;
 }
+
+export type EventMetadata<T> = IntrinsicObfuscate<{ [k in keyof T]: IntrinsicCallbackGuards<T[k]> }>;
 
 export type ArbitaryGuards = { [key: string]: [t.check<unknown>[], t.check<unknown> | undefined] };

--- a/src/events/types.d.ts
+++ b/src/events/types.d.ts
@@ -94,11 +94,15 @@ export interface EventCreateConfiguration<T> {
 export interface GlobalEvent<S, C> {
 	/**
 	 * This is the server implementation of the network and does not exist on the client.
+	 *
+	 * @metadata macro {@link config intrinsic-const} {@link config intrinsic-middleware}
 	 */
 	createServer(config: Partial<EventCreateConfiguration<S>>): ServerHandler<C, S>;
 
 	/**
 	 * This is the client implementation of the network and does not exist on the server.
+	 *
+	 * @metadata macro {@link config intrinsic-const} {@link config intrinsic-middleware}
 	 */
 	createClient(config: Partial<EventCreateConfiguration<C>>): ClientHandler<S, C>;
 

--- a/src/functions/createNetworkingFunction.ts
+++ b/src/functions/createNetworkingFunction.ts
@@ -66,35 +66,43 @@ export function createNetworkingFunction<S, C>(
 
 	return {
 		createServer(config, meta) {
-			if (!RunService.IsServer()) {
+			if (RunService.IsRunning() && !RunService.IsServer()) {
 				return undefined!;
 			}
 
-			setupRemotes();
-			return (server ??= createServerHandler<S, C>(
-				serverRemotes,
-				clientRemotes,
-				networkInfos,
-				meta!,
-				getDefaultConfiguration(config),
-				signals,
-			));
+			if (server === undefined) {
+				setupRemotes();
+				server = createServerHandler<S, C>(
+					serverRemotes,
+					clientRemotes,
+					networkInfos,
+					meta!,
+					getDefaultConfiguration(config),
+					signals,
+				);
+			}
+
+			return server;
 		},
 
 		createClient(config, meta) {
-			if (!RunService.IsClient()) {
+			if (RunService.IsRunning() && !RunService.IsClient()) {
 				return undefined!;
 			}
 
-			setupRemotes();
-			return (client ??= createClientHandler<S, C>(
-				serverRemotes,
-				clientRemotes,
-				networkInfos,
-				meta!,
-				getDefaultConfiguration(config),
-				signals,
-			));
+			if (client === undefined) {
+				setupRemotes();
+				client = createClientHandler<S, C>(
+					serverRemotes,
+					clientRemotes,
+					networkInfos,
+					meta!,
+					getDefaultConfiguration(config),
+					signals,
+				);
+			}
+
+			return client;
 		},
 
 		registerHandler(key, callback) {

--- a/src/functions/createNetworkingFunction.ts
+++ b/src/functions/createNetworkingFunction.ts
@@ -27,16 +27,16 @@ function getDefaultConfiguration<T>(config: Partial<FunctionCreateConfiguration<
 
 export function createNetworkingFunction<S, C>(
 	globalName: string,
-	serverEvents: ArbitaryGuards,
-	clientEvents: ArbitaryGuards,
+	serverNamesPlain: string[],
+	clientNamesPlain: string[],
 ): GlobalFunction<S, C> {
 	const networkInfos = new Map<string, NetworkInfo>();
 	const serverRemotes = new Map<string, RemoteEvent>();
 	const clientRemotes = new Map<string, RemoteEvent>();
 	const signals = createSignalContainer<FunctionNetworkingEvents>();
 
-	const serverNames = Object.keys(serverEvents).map((x) => `s:${x}`);
-	const clientNames = Object.keys(clientEvents).map((x) => `c:${x}`);
+	const serverNames = serverNamesPlain.map((x) => `s:${x}`);
+	const clientNames = clientNamesPlain.map((x) => `c:${x}`);
 
 	const setupRemotes = () => {
 		populateInstanceMap("RemoteEvent", `functions-${globalName}`, serverNames, serverRemotes);
@@ -65,7 +65,7 @@ export function createNetworkingFunction<S, C>(
 	let client: ClientHandler<S, C> | undefined;
 
 	return {
-		createServer(config) {
+		createServer(config, meta) {
 			if (!RunService.IsServer()) {
 				return undefined!;
 			}
@@ -75,14 +75,13 @@ export function createNetworkingFunction<S, C>(
 				serverRemotes,
 				clientRemotes,
 				networkInfos,
-				serverEvents,
-				clientEvents,
+				meta!,
 				getDefaultConfiguration(config),
 				signals,
 			));
 		},
 
-		createClient(config) {
+		createClient(config, meta) {
 			if (!RunService.IsClient()) {
 				return undefined!;
 			}
@@ -92,8 +91,7 @@ export function createNetworkingFunction<S, C>(
 				serverRemotes,
 				clientRemotes,
 				networkInfos,
-				serverEvents,
-				clientEvents,
+				meta!,
 				getDefaultConfiguration(config),
 				signals,
 			));

--- a/src/functions/types.d.ts
+++ b/src/functions/types.d.ts
@@ -101,11 +101,15 @@ export interface FunctionCreateConfiguration<T> {
 export interface GlobalFunction<S, C> {
 	/**
 	 * This is the server implementation of the network and does not exist on the client.
+	 *
+	 * @metadata macro {@link config intrinsic-const} {@link config intrinsic-middleware}
 	 */
 	createServer(config: Partial<FunctionCreateConfiguration<S>>): ServerHandler<C, S>;
 
 	/**
 	 * This is the client implementation of the network and does not exist on the server.
+	 *
+	 * @metadata macro {@link config intrinsic-const} {@link config intrinsic-middleware}
 	 */
 	createClient(config: Partial<FunctionCreateConfiguration<C>>): ClientHandler<S, C>;
 

--- a/src/functions/types.d.ts
+++ b/src/functions/types.d.ts
@@ -3,7 +3,7 @@ import { NetworkingFunctionError } from "../functions/errors";
 import {
 	FunctionParameters,
 	FunctionReturn,
-	IntrinsicCallbackGuards,
+	IntrinsicTupleGuards,
 	IntrinsicGuard,
 	IntrinsicObfuscate,
 	NetworkingObfuscationMarker,
@@ -174,7 +174,7 @@ export interface RequestInfo {
  * We must generate the return type of events separately as Flamework no longer includes all type guards on both server and client.
  */
 export type FunctionMetadata<T, R> = Modding.Many<{
-	incoming: IntrinsicObfuscate<{ [k in keyof T]: IntrinsicCallbackGuards<T[k]> }>;
+	incoming: IntrinsicObfuscate<{ [k in keyof T]: IntrinsicTupleGuards<Parameters<T[k]>> }>;
 	returns: IntrinsicObfuscate<{ [k in keyof R]: IntrinsicGuard<ReturnType<R[k]>> }>;
 }>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,13 +29,6 @@ export namespace Networking {
 	export const Skip = NetworkingSkip;
 
 	/**
-	 * A function that generates middleware.
-	 * @hidden
-	 * @deprecated Use {@link EventMiddleware} or {@link FunctionMiddleware}
-	 */
-	export type MiddlewareFactory<I extends readonly unknown[] = unknown[], O = void> = _MiddlewareFactory<I, O>;
-
-	/**
 	 * A function that generates an event middleware.
 	 */
 	export type EventMiddleware<I extends readonly unknown[] = unknown[]> = _EventMiddleware<I>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,38 @@ import {
 	EventMiddleware as _EventMiddleware,
 	FunctionMiddleware as _FunctionMiddleware,
 } from "./middleware/types";
+import { createNetworkingEvent } from "./events/createNetworkingEvent";
+import { createNetworkingFunction } from "./functions/createNetworkingFunction";
+import { IntrinsicDeclaration, ObfuscateNames } from "./types";
 
 export namespace Networking {
 	/**
 	 * Creates a new event based off the supplied types.
 	 * @param serverMiddleware Middleware for server events
 	 * @param clientMiddleware Middleware for client events
+	 * @metadata macro
 	 */
-	export declare function createEvent<S, C>(): GlobalEvent<S, C>;
+	export function createEvent<S, C>(
+		name?: IntrinsicDeclaration,
+		server?: ObfuscateNames<keyof S>,
+		client?: ObfuscateNames<keyof C>,
+	): GlobalEvent<S, C> {
+		return createNetworkingEvent(name!, server!, client!);
+	}
 
 	/**
 	 * Creates a new function event based off the supplied types.
 	 * @param serverMiddleware Middleware for server events
 	 * @param clientMiddleware Middleware for client events
+	 * @metadata macro
 	 */
-	export declare function createFunction<S, C>(): GlobalFunction<S, C>;
+	export function createFunction<S, C>(
+		name?: IntrinsicDeclaration,
+		server?: ObfuscateNames<keyof S>,
+		client?: ObfuscateNames<keyof C>,
+	): GlobalFunction<S, C> {
+		return createNetworkingFunction(name!, server!, client!);
+	}
 
 	/**
 	 * Stops networking function middleware.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
-import { EventConfiguration, GlobalEvent } from "./events/types";
-import { FunctionConfiguration, GlobalFunction } from "./functions/types";
+import { GlobalEvent } from "./events/types";
+import { GlobalFunction } from "./functions/types";
 import { Skip as NetworkingSkip } from "./middleware/skip";
 import { NetworkingFunctionError } from "./functions/errors";
 import {
-	EventMiddlewareList,
-	FunctionMiddlewareList,
 	MiddlewareFactory as _MiddlewareFactory,
 	EventMiddleware as _EventMiddleware,
 	FunctionMiddleware as _FunctionMiddleware,
@@ -16,22 +14,14 @@ export namespace Networking {
 	 * @param serverMiddleware Middleware for server events
 	 * @param clientMiddleware Middleware for client events
 	 */
-	export declare function createEvent<S, C>(
-		serverMiddleware?: EventMiddlewareList<S>,
-		clientMiddleware?: EventMiddlewareList<C>,
-		configOptions?: Partial<EventConfiguration>,
-	): GlobalEvent<S, C>;
+	export declare function createEvent<S, C>(): GlobalEvent<S, C>;
 
 	/**
 	 * Creates a new function event based off the supplied types.
 	 * @param serverMiddleware Middleware for server events
 	 * @param clientMiddleware Middleware for client events
 	 */
-	export declare function createFunction<S, C>(
-		serverMiddleware?: FunctionMiddlewareList<S>,
-		clientMiddleware?: FunctionMiddlewareList<C>,
-		configOptions?: Partial<FunctionConfiguration>,
-	): GlobalFunction<S, C>;
+	export declare function createFunction<S, C>(): GlobalFunction<S, C>;
 
 	/**
 	 * Stops networking function middleware.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -24,7 +24,7 @@ export interface NetworkingObfuscationMarker {
 	 * @hidden
 	 * @deprecated
 	 */
-	readonly _nominal_NetworkingObfuscationMarker: unique symbol;
+	readonly _flamework_key_obfuscation: "remotes";
 }
 
 export type FunctionParameters<T> = T extends (...args: infer P) => unknown ? P : never;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -43,7 +43,7 @@ export type ObfuscateNames<T> = Modding.Many<(T extends T ? Modding.Obfuscate<T 
 export type IntrinsicObfuscate<T> = Modding.Intrinsic<"obfuscate-obj", [T, "remotes"], Record<string, T[keyof T]>>;
 
 /** @hidden Intrinsic feature not intended for users */
-export type IntrinsicCallbackGuards<T> = Modding.Intrinsic<"callback-guards", [T], GuardType>;
+export type IntrinsicTupleGuards<T> = Modding.Intrinsic<"tuple-guards", [T], GuardType>;
 
 /** @hidden Intrinsic feature not intended for users */
 export type IntrinsicGuard<T> = Modding.Intrinsic<"guard", [T], t.check<T>>;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,6 @@
+import { Modding } from "@flamework/core";
+import { t } from "@rbxts/t";
+
 export interface NetworkInfo {
 	/**
 	 * The name provided for this event.
@@ -33,3 +36,19 @@ export type FunctionReturn<T> = T extends (...args: never[]) => infer R ? R : ne
 export type StripTSDoc<T, E extends string | number | symbol = keyof T> = {
 	[k in E]: k extends keyof T ? T[k] : never;
 };
+
+export type ObfuscateNames<T> = Modding.Many<(T extends T ? Modding.Obfuscate<T & string, "remotes"> : never)[]>;
+
+/** @hidden Intrinsic feature not intended for users */
+export type IntrinsicObfuscate<T> = Modding.Intrinsic<"obfuscate-obj", [T, "remotes"], Record<string, T[keyof T]>>;
+
+/** @hidden Intrinsic feature not intended for users */
+export type IntrinsicCallbackGuards<T> = Modding.Intrinsic<"callback-guards", [T], GuardType>;
+
+/** @hidden Intrinsic feature not intended for users */
+export type IntrinsicGuard<T> = Modding.Intrinsic<"guard", [T], t.check<T>>;
+
+/** @hidden Intrinsic feature not intended for users */
+export type IntrinsicDeclaration = Modding.Intrinsic<"declaration-uid", [], string>;
+
+type GuardType = [t.check<unknown>[], t.check<unknown> | undefined];


### PR DESCRIPTION
BREAKING: `connect` no longer accepts connection-specific guards. This is intended to be replaced with user macros.
BREAKING: `createEvent`/`createFunction` no longer accept middleware or configuration.
BREAKING: `GlobalEvents.server` and `GlobalEvents.client` were replaced with `createServer(config)` and `createClient(config)` respectively.
BREAKING: Removes `MiddlewareFactory` which is an already deprecated API.

- Adds support for mock networking in edit mode (e.g in UI stories)
- Server guards and server config (including middleware) are no longer unnecessarily exposed to the client
- All configuration, including middleware, is now under a single object instead of 3 separate parameters.

https://github.com/rbxts-flamework/transformer/pull/35