### PR TITLE
Remove StripTSDoc utility type

### DIFF
--- a/src/events/types.d.ts
+++ b/src/events/types.d.ts
@@ -3,7 +3,6 @@ import {
 	IntrinsicTupleGuards,
 	IntrinsicObfuscate,
 	NetworkingObfuscationMarker,
-	StripTSDoc,
 	NetworkUnreliable,
 	ObfuscateNames,
 } from "../types";
@@ -69,7 +68,7 @@ export interface ClientReceiver<I extends unknown[]> {
 
 export type ServerHandler<E, R> = NetworkingObfuscationMarker & {
 	[k in keyof Events<E>]: ServerSender<FunctionParameters<E[k]>>;
-} & { [k in keyof StripTSDoc<Events<R>>]: ServerReceiver<FunctionParameters<R[k]>> } & {
+} & { [k in keyof Events<R>]: ServerReceiver<FunctionParameters<R[k]>> } & {
 	[k in keyof EventNamespaces<E>]: ServerHandler<E[k], k extends keyof R ? R[k] : {}>;
 } & {
 	[k in keyof EventNamespaces<R>]: ServerHandler<k extends keyof E ? E[k] : {}, R[k]>;
@@ -77,7 +76,7 @@ export type ServerHandler<E, R> = NetworkingObfuscationMarker & {
 
 export type ClientHandler<E, R> = NetworkingObfuscationMarker & {
 	[k in keyof Events<E>]: ClientSender<FunctionParameters<E[k]>>;
-} & { [k in keyof StripTSDoc<Events<R>>]: ClientReceiver<FunctionParameters<R[k]>> } & {
+} & { [k in keyof Events<R>]: ClientReceiver<FunctionParameters<R[k]>> } & {
 	[k in keyof EventNamespaces<E>]: ClientHandler<E[k], k extends keyof R ? R[k] : {}>;
 } & {
 	[k in keyof EventNamespaces<R>]: ClientHandler<k extends keyof E ? E[k] : {}, R[k]>;

--- a/src/functions/types.d.ts
+++ b/src/functions/types.d.ts
@@ -5,7 +5,6 @@ import {
 	IntrinsicTupleGuards,
 	IntrinsicObfuscate,
 	NetworkingObfuscationMarker,
-	StripTSDoc,
 	ObfuscateNames,
 } from "../types";
 import { FunctionNetworkingEvents } from "../handlers";
@@ -75,7 +74,7 @@ export interface ClientReceiver<I extends unknown[], O> {
 
 export type ServerHandler<E, R> = NetworkingObfuscationMarker & {
 	[k in keyof Functions<E>]: ServerSender<FunctionParameters<E[k]>, FunctionReturn<E[k]>>;
-} & { [k in keyof StripTSDoc<Functions<R>>]: ServerReceiver<FunctionParameters<R[k]>, FunctionReturn<R[k]>> } & {
+} & { [k in keyof Functions<R>]: ServerReceiver<FunctionParameters<R[k]>, FunctionReturn<R[k]>> } & {
 	[k in keyof FunctionNamespaces<E>]: ServerHandler<E[k], k extends keyof R ? R[k] : {}>;
 } & {
 	[k in keyof FunctionNamespaces<R>]: ServerHandler<k extends keyof E ? E[k] : {}, R[k]>;
@@ -83,7 +82,7 @@ export type ServerHandler<E, R> = NetworkingObfuscationMarker & {
 
 export type ClientHandler<E, R> = NetworkingObfuscationMarker & {
 	[k in keyof Functions<E>]: ClientSender<FunctionParameters<E[k]>, FunctionReturn<E[k]>>;
-} & { [k in keyof StripTSDoc<Functions<R>>]: ClientReceiver<FunctionParameters<R[k]>, FunctionReturn<R[k]>> } & {
+} & { [k in keyof Functions<R>]: ClientReceiver<FunctionParameters<R[k]>, FunctionReturn<R[k]>> } & {
 	[k in keyof FunctionNamespaces<E>]: ClientHandler<E[k], k extends keyof R ? R[k] : {}>;
 } & {
 	[k in keyof FunctionNamespaces<R>]: ClientHandler<k extends keyof E ? E[k] : {}, R[k]>;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,13 +32,6 @@ export interface NetworkingObfuscationMarker {
 export type FunctionParameters<T> = T extends (...args: infer P) => unknown ? P : never;
 export type FunctionReturn<T> = T extends (...args: never[]) => infer R ? R : never;
 
-/**
- * A very gross hack to get rid of doc comment duplication on events.
- */
-export type StripTSDoc<T, E extends string | number | symbol = keyof T> = {
-	[k in E]: k extends keyof T ? T[k] : never;
-};
-
 export type ObfuscateNames<T> = IntrinsicObfuscateArray<
 	(T extends T ? Modding.Obfuscate<T & string, "remotes"> : never)[],
 	string[]


### PR DESCRIPTION
Whilst the duplicate documentation comments can be annoying, `StripTSDoc` also strips any symbol information which means you are unable to use Find All References on events.