### PR TITLE
Fix duplicated remote

### DIFF
--- a/src/event/createRemoteInstance.ts
+++ b/src/event/createRemoteInstance.ts
@@ -11,6 +11,10 @@ function findByAttribute(parent: Instance, id: string) {
 function waitByAttribute(parent: Instance, id: string) {
 	let instance = findByAttribute(parent, id);
 
+	const watcherThread = task.delay(5, () => {
+		warn(`Flamework is waiting on '${id}' for`, parent);
+	});
+
 	if (!instance) {
 		while (true) {
 			instance = parent.ChildAdded.Wait()[0];
@@ -20,6 +24,8 @@ function waitByAttribute(parent: Instance, id: string) {
 			}
 		}
 	}
+
+	task.cancel(watcherThread);
 
 	return instance;
 }

--- a/src/events/createGenericHandler.ts
+++ b/src/events/createGenericHandler.ts
@@ -26,7 +26,6 @@ export function createGenericHandler<T extends ClientHandler<S, R> | ServerHandl
 		const outgoingChannel = isOutgoing ? metadata.outgoingUnreliable : metadata.incomingUnreliable;
 		const isIncomingUnreliable = incomingChannel[name] === true;
 		const isOutgoingUnreliable = outgoingChannel[name] === true;
-		const isReceiver = receiverNameSet.has(name);
 		const configMiddleware = config.middleware[name as keyof Events<R>];
 		const incomingMiddleware = configMiddleware !== undefined ? table.clone(configMiddleware) : [];
 		const effectiveName = namespaceName !== undefined ? `${namespaceName}/${name}` : name;
@@ -36,7 +35,7 @@ export function createGenericHandler<T extends ClientHandler<S, R> | ServerHandl
 			globalName,
 		};
 
-		if (!config.disableIncomingGuards && isReceiver) {
+		if (!config.disableIncomingGuards && isIncoming) {
 			const guards = metadata.incoming[name];
 			assert(guards);
 

--- a/src/events/createGenericHandler.ts
+++ b/src/events/createGenericHandler.ts
@@ -17,9 +17,15 @@ export function createGenericHandler<T extends ClientHandler<S, R> | ServerHandl
 	const handler = {} as T;
 
 	const receiverNameSet = new Set(metadata.incomingIds);
+	const senderNameSet = new Set(metadata.outgoingIds);
 	for (const name of new Set([...metadata.incomingIds, ...metadata.outgoingIds])) {
-		const isIncomingUnreliable = metadata.incomingUnreliable[name] === true;
-		const isOutgoingUnreliable = metadata.outgoingUnreliable[name] === true;
+		const isIncoming = receiverNameSet.has(name);
+		const isOutgoing = senderNameSet.has(name);
+		// If there is no incoming/outgoing event, use the same reliability as the other.
+		const incomingChannel = isIncoming ? metadata.incomingUnreliable : metadata.outgoingUnreliable;
+		const outgoingChannel = isOutgoing ? metadata.outgoingUnreliable : metadata.incomingUnreliable;
+		const isIncomingUnreliable = incomingChannel[name] === true;
+		const isOutgoingUnreliable = outgoingChannel[name] === true;
 		const isReceiver = receiverNameSet.has(name);
 		const configMiddleware = config.middleware[name as keyof Events<R>];
 		const incomingMiddleware = configMiddleware !== undefined ? table.clone(configMiddleware) : [];


### PR DESCRIPTION
Fixes a bug where Flamework would always create a reliable remote if you had an unreliable remote on a single side.